### PR TITLE
Add createOrder's Logic

### DIFF
--- a/src/main/java/com/finalproject/everrent_be/EverrentBeApplication.java
+++ b/src/main/java/com/finalproject/everrent_be/EverrentBeApplication.java
@@ -3,8 +3,10 @@ package com.finalproject.everrent_be;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class EverrentBeApplication {
 

--- a/src/main/java/com/finalproject/everrent_be/controller/MypageController.java
+++ b/src/main/java/com/finalproject/everrent_be/controller/MypageController.java
@@ -1,0 +1,46 @@
+package com.finalproject.everrent_be.controller;
+
+
+import com.finalproject.everrent_be.dto.ResponseDto;
+import com.finalproject.everrent_be.service.MypageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MypageController {
+
+    private final MypageService mypageService;
+
+    @GetMapping("/mypages/lists")
+    public ResponseDto<?> getMypgLists()
+    {
+        return mypageService.getMypgLists();
+    }
+    @GetMapping("/mypages/expired")
+    public ResponseDto<?> getMypgExpired()
+    {
+        return mypageService.getMypgExpired();
+    }
+
+    @GetMapping("/mypages/waitlists")
+    public ResponseDto<?> getMypgWait()
+    {
+        return mypageService.getMypgWait();
+    }
+
+    @GetMapping("/mypages/confirms")
+    public ResponseDto<?> getMypgConfirm()
+    {
+        return mypageService.getMypgConfirm();
+    }
+
+    @PutMapping("/mypages/confirms/{orderId}")
+    public ResponseDto<?> allowOrder(@PathVariable String orderId)
+    {
+        return mypageService.allowOrder(orderId);
+    }
+}

--- a/src/main/java/com/finalproject/everrent_be/dto/OrderResponseDto.java
+++ b/src/main/java/com/finalproject/everrent_be/dto/OrderResponseDto.java
@@ -22,6 +22,8 @@ public class OrderResponseDto {
 
     public OrderResponseDto(OrderList orderList)
     {
+        this.memberName=orderList.getMember().getMemberName();
+        this.productName=orderList.getProduct().getProductName();
         this.buyStart= orderList.getBuyStart();
         this.buyEnd= orderList.getBuyEnd();
         this.confirm= orderList.getConfirm();

--- a/src/main/java/com/finalproject/everrent_be/dto/ProductRequestDto.java
+++ b/src/main/java/com/finalproject/everrent_be/dto/ProductRequestDto.java
@@ -24,6 +24,6 @@ public class ProductRequestDto {
     private String cateId;
     private String rentStart;
     private String rentEnd;
-    private String confirm;
+
 
 }

--- a/src/main/java/com/finalproject/everrent_be/dto/ProductResponseDto.java
+++ b/src/main/java/com/finalproject/everrent_be/dto/ProductResponseDto.java
@@ -28,8 +28,8 @@ public class ProductResponseDto {
     private String cateId;
     private String rentStart;
     private String rentEnd;
-
     private String confirm;
+
     private LocalDateTime writeAt;
 
 
@@ -45,8 +45,8 @@ public class ProductResponseDto {
         this.cateId=product.getCateId();
         this.writeAt=product.getModifiedAt();
         this.rentStart=product.getRentStart();
-        this.confirm=product.getConfirm();
         this.rentEnd=product.getRentEnd();
+        this.confirm=product.getConfirm();
     }
 
 }

--- a/src/main/java/com/finalproject/everrent_be/exception/ErrorCode.java
+++ b/src/main/java/com/finalproject/everrent_be/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     INVALID_START_DATE("INVALID_START_DATE","렌트 시작일을 확인해 주세요."),
     INVALID_END_DATE("INVALID_END_DATE","렌트 반납일을 확인해 주세요."),
     INVALID_CREATE("INVALID_CREATE", "본인이 작성한 상품은 구매할 수 없습니다."),
+    INVALID_CONFIRM("INVALID_CONFIRM","상품 상태를 업데이트할 수 없습니다."),
 
     //댓글 관련 오류
     COMMENT_NOT_FOUND("COMMENT_NOT_FOUND", "댓글을 찾을 수 없습니다."),

--- a/src/main/java/com/finalproject/everrent_be/jwt/TokenProvider.java
+++ b/src/main/java/com/finalproject/everrent_be/jwt/TokenProvider.java
@@ -36,11 +36,6 @@ public class TokenProvider {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    // 토큰에서 회원 정보 추출
-    public String getUserPk(String token) {
-        return Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody().getSubject();
-    }
-
 
     public TokenDto generateTokenDto(Authentication authentication) {
         // 권한들 가져오기

--- a/src/main/java/com/finalproject/everrent_be/model/Member.java
+++ b/src/main/java/com/finalproject/everrent_be/model/Member.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
+import java.util.List;
 import java.util.UUID;
 
 @NoArgsConstructor
@@ -39,6 +40,11 @@ public class Member extends Timestamped {
     @Column(nullable = false)
     private String password;
 
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Product> products;
+
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderList> orderLists;
     @Column
     private String address;
     @Column

--- a/src/main/java/com/finalproject/everrent_be/model/OrderList.java
+++ b/src/main/java/com/finalproject/everrent_be/model/OrderList.java
@@ -37,4 +37,11 @@ public class OrderList extends Timestamped {
     @Column(nullable = false)
     private String confirm;
 
+
+    public void updateConfirm(String confirm)
+    {
+        this.confirm=confirm;
+
+    }
+
 }

--- a/src/main/java/com/finalproject/everrent_be/model/Product.java
+++ b/src/main/java/com/finalproject/everrent_be/model/Product.java
@@ -61,8 +61,12 @@ public class Product extends Timestamped {
         this.cateId=productRequestDto.getCateId();
         this.rentStart=productRequestDto.getRentStart();
         this.rentEnd=productRequestDto.getRentEnd();
-        this.confirm=productRequestDto.getConfirm();
+        this.confirm="1";
         this.member=member;
+    }
+    public void updateConfirm(String confirm)
+    {
+        this.confirm=confirm;
     }
 
 }

--- a/src/main/java/com/finalproject/everrent_be/repository/OrderListRepository.java
+++ b/src/main/java/com/finalproject/everrent_be/repository/OrderListRepository.java
@@ -1,6 +1,7 @@
 package com.finalproject.everrent_be.repository;
 
 
+import com.finalproject.everrent_be.model.Member;
 import com.finalproject.everrent_be.model.OrderList;
 import com.finalproject.everrent_be.model.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,5 +13,5 @@ import java.util.List;
 @Repository
 public interface OrderListRepository extends JpaRepository<OrderList, Long> {
 
-    List<OrderList> findAllByProduct(Product product);
+    List<OrderList> findAllByMember(Member member);
 }

--- a/src/main/java/com/finalproject/everrent_be/repository/ProductRepository.java
+++ b/src/main/java/com/finalproject/everrent_be/repository/ProductRepository.java
@@ -1,5 +1,6 @@
 package com.finalproject.everrent_be.repository;
 
+import com.finalproject.everrent_be.model.Member;
 import com.finalproject.everrent_be.model.Product;
 import jdk.jfr.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,5 +13,7 @@ import java.util.List;
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     List<Product> findAllByCateId(String cateId);
+    List<Product> findAllByMember(Member member);
+
 
 }

--- a/src/main/java/com/finalproject/everrent_be/service/MypageService.java
+++ b/src/main/java/com/finalproject/everrent_be/service/MypageService.java
@@ -1,0 +1,104 @@
+package com.finalproject.everrent_be.service;
+
+
+import com.finalproject.everrent_be.dto.OrderResponseDto;
+import com.finalproject.everrent_be.dto.ProductResponseDto;
+import com.finalproject.everrent_be.dto.ResponseDto;
+import com.finalproject.everrent_be.model.Member;
+import com.finalproject.everrent_be.model.OrderList;
+import com.finalproject.everrent_be.model.Product;
+import com.finalproject.everrent_be.repository.OrderListRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MypageService {
+
+    private final MemberService memberService;
+    private final OrderListRepository orderListRepository;
+
+
+    public ResponseDto<?> getMypgLists()
+    {
+        Member member=memberService.getMemberfromContext();
+
+        List<Product> products=member.getProducts();
+        List<ProductResponseDto> productResponseDtos=new ArrayList<>();
+        for(Product product:products)
+        {
+            productResponseDtos.add(new ProductResponseDto(product));
+        }
+        return ResponseDto.is_Success(productResponseDtos);
+    }
+
+    public ResponseDto<?> getMypgExpired()
+    {
+        Member member=memberService.getMemberfromContext();
+
+        List<Product> products=member.getProducts();
+        List<ProductResponseDto> productResponseDtos=new ArrayList<>();
+        for(Product product:products)
+        {
+            if(product.getConfirm()=="2")
+            {
+                productResponseDtos.add(new ProductResponseDto(product));
+            }
+        }
+        return ResponseDto.is_Success(productResponseDtos);
+    }
+
+    public ResponseDto<?> getMypgWait()
+    {
+        Member member=memberService.getMemberfromContext();
+        List<OrderList> orderLists=member.getOrderLists();
+        List<OrderResponseDto> orderResponseDtos=new ArrayList<>();
+        for(OrderList orderList:orderLists)
+        {
+            if(orderList.getConfirm()=="1")
+            {
+                orderResponseDtos.add(new OrderResponseDto(orderList));
+            }
+        }
+        return ResponseDto.is_Success(orderResponseDtos);
+    }
+
+    public ResponseDto<?> getMypgConfirm()
+    {
+        Member member=memberService.getMemberfromContext();
+        List<OrderList> orderLists=member.getOrderLists();
+        List<OrderResponseDto> orderResponseDtos=new ArrayList<>();
+        for(OrderList orderList:orderLists)
+        {
+            if(orderList.getConfirm()=="2")
+            {
+                orderResponseDtos.add(new OrderResponseDto(orderList));
+            }
+        }
+        return ResponseDto.is_Success(orderResponseDtos);
+    }
+
+
+
+    @Transactional
+    public ResponseDto<?> allowOrder(String orderId)
+    {
+        Optional<OrderList> optionalOrderList=orderListRepository.findById(Long.valueOf(orderId));
+        OrderList orderList=optionalOrderList.get();
+        orderList.updateConfirm("2");
+        OrderResponseDto orderResponseDto=new OrderResponseDto(orderList);
+
+        return ResponseDto.is_Success(orderResponseDto);
+    }
+
+
+
+
+
+
+}

--- a/src/main/java/com/finalproject/everrent_be/service/OrderService.java
+++ b/src/main/java/com/finalproject/everrent_be/service/OrderService.java
@@ -13,6 +13,8 @@ import com.finalproject.everrent_be.repository.OrderListRepository;
 import com.finalproject.everrent_be.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -28,6 +30,8 @@ public class OrderService {
     private final MemberService memberService;
     private final ProductRepository productRepository;
     private final OrderListRepository orderListRepository;
+
+    @Transactional
     public ResponseDto<?> creatOrder(String productId, OrderRequestDto orderRequestDto)
     {
         Member member=memberService.getMemberfromContext();
@@ -56,14 +60,7 @@ public class OrderService {
 
         orderListRepository.save(orderList);
 
-        OrderResponseDto orderResponseDto=OrderResponseDto.builder()
-                .id(orderList.getId())
-                .memberName(orderList.getMember().getMemberName())
-                .productName(orderList.getProduct().getProductName())
-                .buyStart(orderList.getBuyStart())
-                .buyEnd(orderList.getBuyEnd())
-                .confirm(orderList.getConfirm())
-                .build();
+        OrderResponseDto orderResponseDto=new OrderResponseDto(orderList);
 
         return ResponseDto.is_Success(orderResponseDto);
 
@@ -75,13 +72,7 @@ public class OrderService {
         Optional<OrderList> optionalOrder= orderListRepository.findById(Long.valueOf(orderId));
         OrderList orderList =optionalOrder.get();
 
-        OrderResponseDto orderResponseDto=OrderResponseDto.builder()
-                .id(orderList.getId())
-                .memberName(orderList.getMember().getMemberName())
-                .productName(orderList.getProduct().getProductName())
-                .buyStart(orderList.getBuyStart())
-                .buyEnd(orderList.getBuyEnd())
-                .build();
+        OrderResponseDto orderResponseDto=new OrderResponseDto(orderList);
 
         return ResponseDto.is_Success(orderResponseDto);
     }

--- a/src/main/java/com/finalproject/everrent_be/service/ProductService.java
+++ b/src/main/java/com/finalproject/everrent_be/service/ProductService.java
@@ -1,6 +1,7 @@
 package com.finalproject.everrent_be.service;
 
 import com.finalproject.everrent_be.dto.*;
+import com.finalproject.everrent_be.exception.ErrorCode;
 import com.finalproject.everrent_be.jwt.TokenProvider;
 import com.finalproject.everrent_be.model.Member;
 import com.finalproject.everrent_be.model.Product;
@@ -100,9 +101,14 @@ public class ProductService {
                 () -> new IllegalArgumentException("해당 상품이 존재하지 않습니다.")
         );
         Member member = product.getMember();
+        if (product.getConfirm()!="1")
+        {
+            return ResponseDto.is_Fail(INVALID_CONFIRM);
+        }
         if(!verifiedMember(request,member)){
             return ResponseDto.is_Fail(MEMBER_NOT_ALLOWED);
         }
+
         String url=fileUploadService.uploadImage(multipartFile);
         product.update(requestDto,member,url);
         ProductResponseDto productResponseDto=new ProductResponseDto(product);

--- a/src/main/java/com/finalproject/everrent_be/service/Scheduler.java
+++ b/src/main/java/com/finalproject/everrent_be/service/Scheduler.java
@@ -1,0 +1,56 @@
+package com.finalproject.everrent_be.service;
+
+
+import com.finalproject.everrent_be.model.Product;
+import com.finalproject.everrent_be.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.List;
+
+@RequiredArgsConstructor // final 멤버 변수를 자동으로 생성합니다.
+@Component // 스프링이 필요 시 자동으로 생성하는 클래스 목록에 추가합니다.
+public class Scheduler {
+
+    private final ProductRepository productRepository;
+
+
+    // 초, 분, 시, 일, 월, 주 순서
+    @Scheduled(cron = "0 01 00 * * *")
+    public void deleteEmptyComment() throws InterruptedException {
+
+        List<Product> products = productRepository.findAll();
+        LocalDate now = LocalDate.now();
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Date nowDate= null;
+        Date expired = null;
+
+        boolean check=false;
+        for(Product product:products)
+        {
+            try{
+                nowDate = sdf.parse(String.valueOf(now));
+                expired = sdf.parse(product.getRentEnd());
+
+
+                if(expired.before(nowDate))
+                {
+                    product.updateConfirm("2");
+                    productRepository.save(product);
+                    check=true;
+                }
+            }catch (ParseException e) {
+                e.printStackTrace();
+            }
+        }
+        if(check==false){
+            System.out.println("만료된 게시글이 없습니다.");
+        }
+
+    }
+}


### PR DESCRIPTION
기존 createOrder logic에 반례가 존재해 내용을 수정하였습니다. 또한 repository로 관련 OrderList 객체를 찾는 것이 아닌 연관관계 매핑을 통해 orderList를 검색하였습니다. 
+ createOrder실행을 위해선 매번 OrderList테이블의 size를 구해야하는데, 그냥 Product 테이블에서 OrderList가 추가될 때마다 카운트 되는 컬럼이 존재해도 괜찮을 것 같습니다.